### PR TITLE
Set tools.staticdir.root to user's actual $HOME.  Fixes #61.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -47,6 +47,7 @@ clear
 echo "Thanks. We'll now start cloning into Pidora"
 git clone https://github.com/jacroe/pidora.git -q
 echo "Cloning Pidora complete."
+sed -i "s,/home/pi,$HOME," cpy.conf
 echo
 echo "We'll begin setting up Pidora for use."
 echo "Creating FIFO queue"


### PR DESCRIPTION
If the user running this script is not 'pi', this sed line will point the tools.staticdir.root path to the correct $HOME.  Confirmed working.
